### PR TITLE
Allow preexisting directories in the cache path

### DIFF
--- a/uhura/caches.py
+++ b/uhura/caches.py
@@ -50,7 +50,7 @@ class LocalCache(Cache):
         logger.info(f"Dumping to {self._path}")
 
         if not os.path.exists(os.path.dirname(self._path)):
-            os.makedirs(os.path.dirname(self._path))
+            os.makedirs(os.path.dirname(self._path), exist_ok=True)
         self._serde.write_to_file(self._path, obj)
         return obj
 


### PR DESCRIPTION
When you add a directory to the cache key you can end up with a race where two async writes both try to create the directory and one throws because it now exists. This just allows for the directory to exist already.