### PR TITLE
feat: add file extension in functional reader

### DIFF
--- a/tests/test_caches.py
+++ b/tests/test_caches.py
@@ -11,6 +11,7 @@ import pytest
 from uhura.base import Readable, Writable
 from uhura.caches import (
     CachingService,
+    LocalCache,
 )
 from uhura.caching import (
     cache_local_input,
@@ -20,6 +21,7 @@ from uhura.caching import (
 )
 from uhura.functional import uhura_reader, uhura_writer
 from uhura.modes import fixture_builder_mode, task_test_mode
+from uhura.serde import PickleSerde
 
 
 class RandomReadable(Readable[float]):
@@ -293,3 +295,15 @@ def test_cache_key():
         assert (
             DatabaseReader("id1").read() != DatabaseReader("id2").read()
         ), "Cache key being ignored"
+
+
+def test_local_cache_path_renders_path_with_file_extension_from_serde_if_not_present():
+    cache_path = "my/cache/dir"
+    serde = PickleSerde()
+    local_cache = LocalCache(cache_path, serde)
+
+    base_path = "base/path"
+    cache_key = "filename"
+    rendered_path = local_cache.render_path(base_path, cache_key, serde)
+
+    assert rendered_path.split(".")[-1] == "pkl"

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -1,8 +1,12 @@
-from uhura.serde import PickleSerde
+import os
+from tempfile import TemporaryDirectory
+from typing import Any
+
+import pytest
+
 from uhura.base import Readable
 from uhura.modes import fixture_builder_mode, task_test_mode
-from tempfile import TemporaryDirectory
-import os
+from uhura.serde import PickleSerde, Serde
 
 
 class FakeSerde(PickleSerde):
@@ -44,3 +48,13 @@ def test_can_have_custom_serde():
             assert not test_serde.has_been_read
             client.read()
             assert test_serde.has_been_read
+
+
+def test_serde_subclass_requires_file_extension():
+    with pytest.raises(AttributeError):
+        class Bad(Serde[Any]):
+            def read_from_file(self, file):
+                pass
+
+            def write_to_file(self, file, obj: Any):
+                pass

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -51,7 +51,8 @@ def test_can_have_custom_serde():
 
 
 def test_serde_subclass_requires_file_extension():
-    with pytest.raises(AttributeError):
+    with pytest.raises(AssertionError):
+
         class Bad(Serde[Any]):
             def read_from_file(self, file):
                 pass

--- a/uhura/serde.py
+++ b/uhura/serde.py
@@ -10,8 +10,8 @@ class Serde(Generic[SerdeType]):
     file_extension: ClassVar[str]
 
     def __init_subclass__(cls) -> None:
-        assert (
-            cls.file_extension is not None
+        assert hasattr(
+            cls, "file_extension"
         ), "Serde implementations must have a valid file_extension"
         return super().__init_subclass__()
 

--- a/uhura/serde.py
+++ b/uhura/serde.py
@@ -1,5 +1,5 @@
 import pickle
-from typing import TypeVar, Generic, ClassVar, Any
+from typing import Any, ClassVar, Generic, TypeVar
 
 import pandas as pd
 
@@ -8,6 +8,11 @@ SerdeType = TypeVar("SerdeType")
 
 class Serde(Generic[SerdeType]):
     file_extension: ClassVar[str]
+
+    def __init_subclass__(cls) -> None:
+        assert cls.file_extension is not None, "Serde implementations must have a valid file_extension"
+        return super().__init_subclass__()
+
 
     def read_from_file(self, file) -> SerdeType:
         raise NotImplementedError()

--- a/uhura/serde.py
+++ b/uhura/serde.py
@@ -10,9 +10,10 @@ class Serde(Generic[SerdeType]):
     file_extension: ClassVar[str]
 
     def __init_subclass__(cls) -> None:
-        assert cls.file_extension is not None, "Serde implementations must have a valid file_extension"
+        assert (
+            cls.file_extension is not None
+        ), "Serde implementations must have a valid file_extension"
         return super().__init_subclass__()
-
 
     def read_from_file(self, file) -> SerdeType:
         raise NotImplementedError()


### PR DESCRIPTION
Makes sure that there's a file extension when using the functional reader, depending on the serde class used.