### PR TITLE
make uhura compatible with python 3.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ keywords =
     distutils
 
 [options]
-python_requires = >=3.8
+python_requires = >=3.7
 
 [files]
 packages =

--- a/uhura/caches.py
+++ b/uhura/caches.py
@@ -8,6 +8,7 @@ from typing import Callable, DefaultDict, Optional, Type  # ParamSpec
 
 from uhura.composition import async_unit, compose
 from uhura.serde import DEFAULT_SERDE, Serde
+from uhura.base import Cacheable
 
 logger = logging.getLogger("uhura.caches")
 
@@ -23,18 +24,6 @@ class Cache(abc.ABC):
 
     @abstractmethod
     def update(self, obj):
-        raise NotImplementedError()
-
-
-class Cacheable:
-    _read_count: Optional[int]  # Created in streaming readables (generators, async iterators etc.)
-
-    def cache_key(self):
-        if hasattr(self, "_read_count"):
-            return os.path.join(self.__class__.__name__, str(self._read_count))
-        return self.__class__.__name__
-
-    def get_serde(self) -> Serde:
         raise NotImplementedError()
 
 

--- a/uhura/caches.py
+++ b/uhura/caches.py
@@ -4,7 +4,7 @@ import os
 from abc import abstractmethod
 from collections import defaultdict
 from inspect import isasyncgenfunction, iscoroutinefunction, isgeneratorfunction
-from typing import Callable, DefaultDict, Optional, Protocol, Type  # ParamSpec
+from typing import Callable, DefaultDict, Optional, Type  # ParamSpec
 
 from uhura.composition import async_unit, compose
 from uhura.serde import DEFAULT_SERDE, Serde
@@ -26,7 +26,7 @@ class Cache(abc.ABC):
         raise NotImplementedError()
 
 
-class Cacheable(Protocol):
+class Cacheable:
     _read_count: Optional[int]  # Created in streaming readables (generators, async iterators etc.)
 
     def cache_key(self):


### PR DESCRIPTION
We still have repos like classifier which use python 3.7. This PR would make it so that we can use uhura with these legacy repos, and actually use uhura to safety check upgrading the python version of these repos. 