### PR TITLE
Attach pickle suffix to functional decorator cache key

### DIFF
--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -5,7 +5,7 @@ from uhura.functional import uhura_reader, uhura_writer
 from uhura.modes import fixture_builder_mode
 
 
-def test_readers_attach_serde_extension():
+def test_readers_attach_pickle_extension():
     @uhura_reader
     def readable_thing_1():
         return "hello"
@@ -16,10 +16,10 @@ def test_readers_attach_serde_extension():
 
         with fixture_builder_mode(known_good_path=output_path, input_path=input_path):
             readable_thing_1()
-        assert os.path.exists(os.path.join(input_path, 'readable_thing_1.pkl'))
+        assert os.path.exists(os.path.join(input_path, f"{readable_thing_1.__qualname__}.pkl"))
 
 
-def test_writers_attach_serde_extension():
+def test_writers_attach_pickle_extension():
     @uhura_writer
     def writable_thing_1(thing: str):
         pass
@@ -30,4 +30,4 @@ def test_writers_attach_serde_extension():
 
         with fixture_builder_mode(known_good_path=output_path, input_path=input_path):
             writable_thing_1("goodbye")
-        assert os.path.exists(os.path.join(output_path, 'writable_thing_1.pkl'))
+        assert os.path.exists(os.path.join(output_path, f"{writable_thing_1.__qualname__}.pkl"))

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,0 +1,33 @@
+import os
+import tempfile
+
+from uhura.functional import uhura_reader, uhura_writer
+from uhura.modes import fixture_builder_mode
+
+
+def test_readers_attach_serde_extension():
+    @uhura_reader
+    def readable_thing_1():
+        return "hello"
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_path = os.path.join(temp_dir, "good_output")
+        input_path = os.path.join(temp_dir, "input")
+
+        with fixture_builder_mode(known_good_path=output_path, input_path=input_path):
+            readable_thing_1()
+        assert os.path.exists(os.path.join(input_path, 'readable_thing_1.pkl'))
+
+
+def test_writers_attach_serde_extension():
+    @uhura_writer
+    def writable_thing_1(thing: str):
+        pass
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_path = os.path.join(temp_dir, "good_output")
+        input_path = os.path.join(temp_dir, "input")
+
+        with fixture_builder_mode(known_good_path=output_path, input_path=input_path):
+            writable_thing_1("goodbye")
+        assert os.path.exists(os.path.join(output_path, 'writable_thing_1.pkl'))

--- a/uhura/functional.py
+++ b/uhura/functional.py
@@ -25,8 +25,7 @@ def uhura_reader(function):
         def read(self):
             return function(*self.params.args, **self.params.kwargs)
 
-        def cache_key(self):
-            return function.__qualname__
+    _SingleFunctionReadable.__name__ = _SingleFunctionReadable.__qualname__ = function.__name__
 
     @wraps(function)
     @match_function_type(function)
@@ -69,8 +68,7 @@ def uhura_writer(function=None, output_arg: Optional[str] = None):
             self.params.arguments[output_arg] = obj
             return function(*self.params.args, **self.params.kwargs)
 
-        def cache_key(self):
-            return function.__qualname__
+    _SingleFunctionWritable.__name__ = _SingleFunctionWritable.__qualname__ = function.__name__
 
     @wraps(function)
     @match_function_type(function)

--- a/uhura/functional.py
+++ b/uhura/functional.py
@@ -25,7 +25,8 @@ def uhura_reader(function):
         def read(self):
             return function(*self.params.args, **self.params.kwargs)
 
-    _SingleFunctionReadable.__name__ = _SingleFunctionReadable.__qualname__ = function.__name__
+        def cache_key(self):
+            return function.__qualname__ + ".pkl"
 
     @wraps(function)
     @match_function_type(function)
@@ -68,7 +69,8 @@ def uhura_writer(function=None, output_arg: Optional[str] = None):
             self.params.arguments[output_arg] = obj
             return function(*self.params.args, **self.params.kwargs)
 
-    _SingleFunctionWritable.__name__ = _SingleFunctionWritable.__qualname__ = function.__name__
+        def cache_key(self):
+            return function.__qualname__ + ".pkl"
 
     @wraps(function)
     @match_function_type(function)


### PR DESCRIPTION
At the moment we don't include a suffix for the fixtures created by the functional decorators, this fixes that.