### PR TITLE
Fix cache comparison key usage in caching.py

### DIFF
--- a/uhura/caching.py
+++ b/uhura/caching.py
@@ -71,7 +71,7 @@ def compare_known_good_output(
             if not cache.exists():
                 raise FileNotFoundError(f"No fixture found for {writable_cls}.")
             expected = cache.get()
-            return comparison[writable_cls.__name__](expected, obj)
+            return comparison[self.cache_key()](expected, obj)
 
         if iscoroutinefunction(writable_cls.write):
             write = async_unit(write)


### PR DESCRIPTION
Currently everything uses the cache key for looking up cache behaviour, but the comparison still uses the class name. This causes issues when trying to merge different readables into one class when dataset specific comparison overrides are needed.